### PR TITLE
Fixed the error 'Failed to 1 FreezeVideo...' which halted the Matlab script.

### DIFF
--- a/GetImage.cpp
+++ b/GetImage.cpp
@@ -59,27 +59,51 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         return;
     }
     
+    // 2023-07-18: Edit to call is_FreezeVideo() > 1 time in attempt to fix the FreezeVideo error
     result = is_FreezeVideo(phCam,IS_WAIT);
-    if(result != IS_SUCCESS)
-    {
-        is_FreeImageMem(phCam,pImage,imgID);
-        mxFree(pImage);
-        is_ExitCamera(phCam);
-        sprintf(errbuffer,"Failed to 1 FreezeVideo: r = %i",result);
-        mexErrMsgTxt(errbuffer);
-        return;
+    INT attemptCounter = 0;
+    INT maxAttemptCounter = 50;
+    attemptCounter = attemptCounter + 1;
+    while(result != IS_SUCCESS){
+        attemptCounter = attemptCounter + 1;
+        result = is_FreezeVideo(phCam, IS_WAIT);
+        if (attemptCounter == maxAttemptCounter && result != IS_SUCCESS){
+            is_FreeImageMem(phCam,pImage,imgID);
+            mxFree(pImage);
+            is_ExitCamera(phCam);
+            sprintf(errbuffer,"Failed to loop for %i loops. Return from FreezeVideo: r = %i",maxAttemptCounter, result);
+            mexErrMsgTxt(errbuffer);
+            return;
+        }
     }
-    
-    result = is_FreezeVideo(phCam,IS_WAIT);
-    if(result != IS_SUCCESS)
-    {
-        is_FreeImageMem(phCam,pImage,imgID);
-        mxFree(pImage);
-        is_ExitCamera(phCam);
-        sprintf(errbuffer,"Failed to 2 FreezeVideo: r = %i",result);
-        mexErrMsgTxt(errbuffer);
-        return;
+    // Comment out following if statement if you want to squash output
+    if (attemptCounter > 1){
+        char testerrbuffer[50];
+        sprintf(testerrbuffer, "Looped freeze video %i times\n", attemptCounter);
+        mexPrintf(testerrbuffer);
+        mexEvalString("drawnow;");
     }
+
+    // if(result != IS_SUCCESS)
+    // {
+    //     is_FreeImageMem(phCam,pImage,imgID);
+    //     mxFree(pImage);
+    //     is_ExitCamera(phCam);
+    //     sprintf(errbuffer,"Failed to 1 FreezeVideo: r = %i",result);
+    //     mexErrMsgTxt(errbuffer);
+    //     return;
+    // }
+    // 
+    // result = is_FreezeVideo(phCam,IS_WAIT);
+    // if(result != IS_SUCCESS)
+    // {
+    //     is_FreeImageMem(phCam,pImage,imgID);
+    //     mxFree(pImage);
+    //     is_ExitCamera(phCam);
+    //     sprintf(errbuffer,"Failed to 2 FreezeVideo: r = %i",result);
+    //     mexErrMsgTxt(errbuffer);
+    //     return;
+    // }
     
     result = is_FreeImageMem(phCam,pImage,imgID);
     if(result != IS_SUCCESS)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ This software uses the C++ API for [Thorlabs CMOS USB cameras](https://www.thorl
 
 This software was developed and tested on [Thorlabs DCC1545M](https://www.thorlabs.com/thorproduct.cfm?partnumber=DCC1545M), Windows 7 and Matlab 2014b. Newer version of Matlab should work. The software can also be modified to include the 'parula' lookup table in Matlab 2015 or later. 
 
+## FreezeVideo() fix
+A common error when using the original code from user 'mdaddysman' was "Failed to 1 FreezeVideo: r = 178." This was due to the Thorlabs function is_FreezeVideo() returning error 178 and would halt the Matlab script and return an error to Matlab. 
+This error corresponds to "IS_TRANSFER_ERROR" and is fixed by changing lines 62-82 of GetImage.cpp to call is_FreezeVideo() > 1 time until a successful image capture occurs. Anecdotely, I have only noticed 1 failed call to is_FreezeVideo() at a time. I do not think the 1 failed call has a significant impact to image capture with this code. 
+Besides this one change, all code is identical to what user 'mdaddysman' provided. Install with the directions below.
+
 ## Installing 
 1. Matlab must be configured with a [C++ compiler](https://www.mathworks.com/support/compilers.html). 
 2. Install the uc480 Version 4.20 SDK [(Direct Link)](https://www.thorlabs.com/software//MUC/DCx/Software/ThorlabsDCx_camera_V4.20.zip) from the [Thorlabs Website](https://www.thorlabs.com/software_pages/ViewSoftwarePage.cfm?Code=ThorCam). 


### PR DESCRIPTION
Simply called is_FreezeVideo() > 1 time until there is a successful return. One future improvement is checking for specific errors returns from is_FreezeVideo() and either stopping the program (e.g. return is 'IS_INVALID_CAMERA_HANDLE') or keep calling is_FreezeVideo() until success.